### PR TITLE
releasetools: Move radio install to a common function

### DIFF
--- a/releasetools.py
+++ b/releasetools.py
@@ -75,12 +75,11 @@ def InstallRawImage(image_data, api_version, input_zip, fn, info, filesmap):
   else:
     print "warning radio-update: no support for api_version less than 3."
 
-def FULLOTA_InstallEnd_MMC(info):
+def InstallRadioFiles(info):
   files = GetRadioFiles(info.input_zip)
   if files == {}:
     print "warning radio-update: no radio image in input target_files; not flashing radio"
     return
-  info.script.UnmountAll()
   info.script.Print("Writing radio image...")
   #Load filesmap file
   filesmap = LoadFilesMap(info.input_zip)
@@ -93,12 +92,10 @@ def FULLOTA_InstallEnd_MMC(info):
   return
 
 def FullOTA_InstallEnd(info):
-  FULLOTA_InstallEnd_MMC(info)
+  InstallRadioFiles(info)
 
 def IncrementalOTA_InstallEnd(info):
-  #TODO: Implement device specific asserstions.
-  print "warning radio-update: no real implementation of IncrementalOTA_InstallEnd."
-  return
+  InstallRadioFiles(info)
 
 def AddTrustZoneAssertion(info):
   # Presence of filesmap indicates packaged firmware


### PR DESCRIPTION
We want to install radios for both full and incremental OTAs. Move the
radio install to a common function for both.

Also don't unmount paritions before the radio install. It isn't needed
and breaks OTAs that may expect system to still be mounted when this
step completes.

Change-Id: I1a46ff7e3777022cb9dbe57c1b53cf9f2fba5a04
